### PR TITLE
Feature request: Go to open PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ The 'GitHub: Set Personal Access Token' should be executed for that.
 ![Create pull request](./images/create-pull-request.png)
 
 * Checkout one of the open pull requests
+* Browser one of the open pull requests in your default browser

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "commands": [
       {
         "command": "extension.setGitHubToken",
-        "title": "GitHub: Set Personal Access Token"
+        "title": "GitHub: Set Personal Access Token..."
       },
       {
         "command": "extension.createPullRequest",
@@ -31,7 +31,11 @@
       },
       {
         "command": "extension.checkoutPullRequests",
-        "title": "GitHub: Checkout open pull requests"
+        "title": "GitHub: Checkout open pull requests..."
+      },
+      {
+        "command": "extension.browserPullRequest",
+        "title": "GitHub: Browser open pull request..."
       }
     ]
   },

--- a/src/github.ts
+++ b/src/github.ts
@@ -78,6 +78,7 @@ interface PullRequest {
   state: 'open' | 'closed';
   title: string;
   body: string;
+  html_url: string;
   head: {
     label: string;
     ref: string;


### PR DESCRIPTION
It would be nice if this extension offered a command to browse an open PR for the current branch. Currently I'm using this custom git command to accomplish this on the command line:

```bash
#!/bin/bash
# Usage: git open-pr [<branch-name>|<pr-id>]
#
# Navigates to the pull request for a branch using the web browser.
# Defaults to current branch.
set -e

branch="${1:-$(git symbolic-ref HEAD)}"
branch="${branch#refs/heads/}"

remote_url() {
  git remote -v | grep "^$1" | head -1 | grep -o 'github.com[/:]\S\+'
}

url="$(remote_url upstream || true)"
url="${url:-$(remote_url github || true)}"
url="${url:-$(remote_url origin || true)}"
url="${url%.git}"

open "https://${url/://}/pull/${branch//\//%2F}"
```