### PR TITLE
feat: allow setting of upstream repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
           "type": "number",
           "default": 5,
           "description": "Interval in seconds to refresh the current pull request status."
+        },
+        "github.upstream": {
+          "type": "string",
+          "description": "By default the extension get the repository and user from .git/config. For forks where upstream is a different repository this could be configured here (e.g. microsoft/typescript)."
         }
       }
     },

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,11 @@
 import * as execa from 'execa';
+import * as vscode from 'vscode';
 
 export async function getGitHubOwnerAndRepository(cwd: string): Promise<string[]> {
+  const defaultUpstream = vscode.workspace.getConfiguration('github').get<string>('upstream', undefined);
+  if (defaultUpstream) {
+    return Promise.resolve(defaultUpstream.split('/'));
+  }
   return execa('git', ['config', '--get-regexp', 'remote\\.origin\\.url'], {cwd})
     .then(result => {
       const match = result.stdout.match(


### PR DESCRIPTION
To make working with upstream repositories (forks) easier it is possible to
set `github.upstream` now. This must be a github slug
(e.g. microsoft/typescript) which is used for all github communication then.

Closes #31