### PR TITLE
feat: allow pr body input via dialog or git editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Current it is possible to do the following:
 * Checkout one of the open pull requests
 * Browse one of the open pull requests in your default browser
 * Display pull request and current status (e.g. mergeable, travis build done, ...) in the StatusBar
-* Create a new pull request based on the current branch and the last commit  
-  The current branch will be requested to merge into master and the pull request title is the commit message summary.
-* Merge current pull rqeuest with either of 'merge', 'squash' or 'rebase' method.
+* Create a new pull request based on the current branch and the last commit
+  The current branch will be requested to merge into master and the pull request title is the commit message summary, or a custom message if configured that way.
+* Merge current pull request with either of 'merge', 'squash' or 'rebase' method.
 * Configure default branch, merge method and refresh interval.
 
 ![Create pull request](images/create-pull-request.png)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,16 @@
         "github.upstream": {
           "type": "string",
           "description": "By default the extension get the repository and user from .git/config. For forks where upstream is a different repository this could be configured here (e.g. microsoft/typescript)."
+        },
+        "github.customPullRequestDescription": {
+          "type": "string",
+          "enum": [
+            "off",
+            "singleLine",
+            "gitEditor"
+          ],
+          "default": "off",
+          "description": "By default the pull request description is the first commit message. When this property is set, the user is asked for a description when creating the PR. This can be a single-line description via an input dialog ('singleLine') or a multi-line markdown description via the editor configured in git ('gitEditor')."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ class Extension {
 
   private async checkVersionAndToken(context: vscode.ExtensionContext, token: string|undefined): Promise<void> {
     const content = await sander.readFile(join(context.extensionPath, 'package.json'));
-    const version = JSON.parse(content).version as string;
+    const version = JSON.parse(content.toString()).version as string;
     const storedVersion = context.globalState.get<string|undefined>('version-test');
     if (version !== storedVersion && !Boolean(token)) {
       context.globalState.update('version-test', version);

--- a/src/github-manager.ts
+++ b/src/github-manager.ts
@@ -95,7 +95,7 @@ export class GitHubManager {
       title: await git.getCommitMessage(firstCommit, this.cwd),
       head: `${owner}:${branch}`,
       base: await this.getDefaultBranch(),
-      body: await git.getCommitBody(firstCommit, this.cwd)
+      body: await git.getPullRequestBody(firstCommit, this.cwd)
     };
     this.channel.appendLine('Create pull request:');
     this.channel.appendLine(JSON.stringify(body, undefined, ' '));

--- a/typings/sander.d.ts
+++ b/typings/sander.d.ts
@@ -1,3 +1,4 @@
 declare module 'sander' {
-  export function readFile(path: string): Promise<string>;
+  export function readFile(path: string): Promise<Buffer>;
+  export function unlink(path: string): Promise<undefined>;
 }


### PR DESCRIPTION
As discussed in #43: add a configuration option to allow the user to specify a custom PR description.

I took the liberty to also add an option to write a multi-line description by launching the git editor, that would suit my use case better than a single-line description.