### PR TITLE
fix: activate extension by setup commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "pull request"
   ],
   "activationEvents": [
-    "workspaceContains:.git"
+    "workspaceContains:.git",
+    "onCommand:vscode-github.setGitHubToken",
+    "onCommand:vscode-github.setGitHubEnterpriseToken"
   ],
   "main": "./out/src/extension",
   "contributes": {


### PR DESCRIPTION
When executing setup commands (github token or enterprise token) the
extension is activated

Closes #126