### PR TITLE
Fix github url regex pattern

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,7 @@ async function getGitHubOwnerAndRepositoryFromGitConfig(cwd: string): Promise<st
 }
 
 export function parseGithubUrl(remote: string): string[] {
-  const match = new RegExp('^git(?:@|://)([^:/]+)[:/]([^/]+)/(.+?)(?:.git)?$', 'i').exec(remote);
+  const match = new RegExp('^git(?:@|://)([^:/]+):/?([^/]+)/(.+?)(?:.git)?$', 'i').exec(remote);
   if (!match) {
     throw new Error(`'${remote}' does not seem to be a valid github url.`);
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,7 @@ async function getGitHubOwnerAndRepositoryFromGitConfig(cwd: string): Promise<st
 }
 
 export function parseGithubUrl(remote: string): string[] {
-  const match = new RegExp('^git(?:@|://)([^:/]+):/?([^/]+)/(.+?)(?:.git)?$', 'i').exec(remote);
+  const match = new RegExp('^git(?:@|://)([^:/]+)(?::|:/|/)([^/]+)/(.+?)(?:.git)?$', 'i').exec(remote);
   if (!match) {
     throw new Error(`'${remote}' does not seem to be a valid github url.`);
   }


### PR DESCRIPTION
Makes a slight tweak to the GitHub URL regex pattern.

The host/path separator in GitHub URLs can be `:` or `:/`, the existing character class `[:/]` only allows the matching of one of `:` or `/`, not both together.

eg. Both `git@github.com:jimcroft/vscode-github.git` and `git@github.com:/jimcroft/vscode-github.git` are valid URLs for git clone but the regex doesn't currently allow the latter (`/` on it's own isn't valid)

This PR addresses that.