### PR TITLE
feat: migrate token storage to support providers

### DIFF
--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -25,7 +25,10 @@ export class SetGithubToken extends Command {
     const input = await vscode.window.showInputBox(options);
     if (input) {
       const tokens = this.context.globalState.get<Tokens>('tokens', {});
-      tokens['github.com'] = input;
+      tokens['github.com'] = {
+        token: input,
+        provider: 'github'
+      };
       this.context.globalState.update('tokens', tokens);
       await this.githubManager.connect(tokens);
     }
@@ -58,11 +61,14 @@ export class SetGithubEnterpriseToken extends Command {
       });
       if (tokenInput) {
         const tokens = this.context.globalState.get<Tokens>('tokens', {});
-        tokens[hostInput] = tokenInput;
+        tokens[hostInput] = {
+          token: tokenInput,
+          provider: 'github'
+        };
         this.context.globalState.update('tokens', tokens);
         this.githubManager.connect(tokens);
       }
     }
-}
+  }
 
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,9 +57,29 @@ export class Extension {
     const token = context.globalState.get<string | undefined>('token');
     if (token) {
       const tokens = context.globalState.get<Tokens>('tokens', {});
-      tokens['github.com'] = token;
+      tokens['github.com'] = {
+        token,
+        provider: 'github'
+      };
       context.globalState.update('tokens', tokens);
       context.globalState.update(token, undefined);
+    }
+    let migrated = false;
+    const tokens = context.globalState.get<{[host: string]: string}>('tokens', {});
+    const struct = Object.keys(tokens).reduce((akku: Tokens, host) => {
+      if (typeof tokens[host] === 'string') {
+        migrated = true;
+        akku[host] = {
+          token: tokens[host],
+          provider: 'github'
+        };
+      } else {
+        akku[host] = tokens[host] as any;
+      }
+      return akku;
+    }, {});
+    if (migrated) {
+      context.globalState.update('tokens', struct);
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { checkExistence } from './git';
 import { GitHubError } from './github';
 import { GitHubManager, Tokens } from './github-manager';
 import { StatusBarManager } from './status-bar-manager';
+import { migrateToken } from './tokens';
 
 @component
 export class Extension {
@@ -32,7 +33,7 @@ export class Extension {
   protected async init(): Promise<void> {
     this.reporter.sendTelemetryEvent('start');
     try {
-      this.migrateToken(this.context);
+      migrateToken(this.context.globalState);
       this.channel.appendLine('Visual Studio Code GitHub Extension');
       const tokens = this.context.globalState.get<Tokens>('tokens');
       this.checkVersionAndToken(this.context, tokens);
@@ -50,36 +51,6 @@ export class Extension {
     } catch (e) {
       this.logAndShowError(e);
       throw e;
-    }
-  }
-
-  private migrateToken(context: vscode.ExtensionContext): void {
-    const token = context.globalState.get<string | undefined>('token');
-    if (token) {
-      const tokens = context.globalState.get<Tokens>('tokens', {});
-      tokens['github.com'] = {
-        token,
-        provider: 'github'
-      };
-      context.globalState.update('tokens', tokens);
-      context.globalState.update(token, undefined);
-    }
-    let migrated = false;
-    const tokens = context.globalState.get<{[host: string]: string}>('tokens', {});
-    const struct = Object.keys(tokens).reduce((akku: Tokens, host) => {
-      if (typeof tokens[host] === 'string') {
-        migrated = true;
-        akku[host] = {
-          token: tokens[host],
-          provider: 'github'
-        };
-      } else {
-        akku[host] = tokens[host] as any;
-      }
-      return akku;
-    }, {});
-    if (migrated) {
-      context.globalState.update('tokens', struct);
     }
   }
 

--- a/src/github-manager.ts
+++ b/src/github-manager.ts
@@ -6,7 +6,10 @@ import {getClient, GitHub, GitHubError, PullRequest, ListPullRequestsParameters,
   PullRequestStatus, Merge, MergeMethod, Repository, Issue, PullRequestComment} from './github';
 
 export interface Tokens {
-  [host: string]: string;
+  [host: string]: {
+    token: string;
+    provider: 'github' | 'gitlab';
+  };
 }
 
 @component
@@ -39,7 +42,7 @@ export class GitHubManager {
 
   public async connect(tokens: Tokens): Promise<void> {
     const hostname = await git.getGitHubHostname(this.cwd);
-    this.github = getClient(await this.getApiEndpoint(), tokens[hostname]);
+    this.github = getClient(await this.getApiEndpoint(), tokens[hostname].token);
   }
 
   private async getApiEndpoint(): Promise<string> {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,32 @@
+import { Memento } from 'vscode';
+import { Tokens } from './github-manager';
+
+export function migrateToken(memento: Memento): void {
+  const token = memento.get<string | undefined>('token');
+  if (token) {
+    const tokens = memento.get<Tokens>('tokens', {});
+    tokens['github.com'] = {
+      token,
+      provider: 'github'
+    };
+    memento.update('tokens', tokens);
+    memento.update(token, undefined);
+  }
+  let migrated = false;
+  const tokens = memento.get<{[host: string]: string}>('tokens', {});
+  const struct = Object.keys(tokens).reduce((akku: Tokens, host) => {
+    if (typeof tokens[host] === 'string') {
+      migrated = true;
+      akku[host] = {
+        token: tokens[host],
+        provider: 'github'
+      };
+    } else {
+      akku[host] = tokens[host] as any;
+    }
+    return akku;
+  }, {});
+  if (migrated) {
+    memento.update('tokens', struct);
+  }
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -5,6 +5,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 // import * as myExtension from '../src/extension';
 import * as git from '../src/git';
+import * as tokens from '../src/tokens';
 
 suite('vscode-github extension tests', () => {
   test('Extension should be active after startup', done => {
@@ -47,5 +48,31 @@ suite('vscode-github extension tests', () => {
     assert.equal(host, 'my.github.com');
     assert.equal(user, 'username');
     assert.equal(repo, 'repo');
+  });
+
+  test('should migrate tokens to a provider structure', (done: MochaDone) => {
+    tokens.migrateToken({
+      get(name: string): any {
+        if (name === 'tokens') {
+          return {
+            host: 'token'
+          };
+        }
+        return undefined;
+      },
+      update(name: string, value: any): Thenable<void> {
+        return Promise.resolve().then(() => {
+          if (name === 'tokens') {
+            assert.deepEqual(value, {
+              host: {
+                token: 'token',
+                provider: 'github'
+              }
+            });
+            done();
+          }
+        });
+      }
+    });
   });
 });


### PR DESCRIPTION
To support different git providers (e.g. gitlab) migrate the token
storage to keep the information to which provider the token belongs.

Preparation for #166 