### PR TITLE
Fix for mergeable status

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -75,7 +75,8 @@ export class WorkflowManager {
     if (list.length !== 1) {
       return undefined;
     }
-    return list[0];
+    const repository = await this.getRepository();
+    return (await repository.getPullRequest(list[0].number)).body;
   }
 
   public async hasPullRequestForCurrentBranch(): Promise<boolean> {


### PR DESCRIPTION
According to [Github Api ](https://developer.github.com/v3/pulls/) mergeable property is only included in single pull request call not list call. Changed so getPullRequestForCurrentBranch after makes list call makes a another call to Github Api to get the latest single Pull Request.