### PR TITLE
fix: parse hostname

### DIFF
--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -2,6 +2,7 @@ import { component, inject } from 'tsdi';
 import * as vscode from 'vscode';
 
 import { Command } from '../command';
+import { getHostname } from '../helper';
 import { WorkflowManager, Tokens } from '../workflow-manager';
 
 @component({eager: true})
@@ -61,7 +62,7 @@ export class SetGithubEnterpriseToken extends Command {
       });
       if (tokenInput) {
         const tokens = this.context.globalState.get<Tokens>('tokens', {});
-        tokens[hostInput] = {
+        tokens[getHostname(hostInput)] = {
           token: tokenInput,
           provider: 'github'
         };
@@ -98,7 +99,7 @@ export class SetGitLabToken extends Command {
       });
       if (tokenInput) {
         const tokens = this.context.globalState.get<Tokens>('tokens', {});
-        tokens[hostInput] = {
+        tokens[getHostname(hostInput)] = {
           token: tokenInput,
           provider: 'gitlab'
         };

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -24,3 +24,11 @@ export function getConfiguration(): Configuration {
   }
   return config;
 }
+
+export function getHostname(input: string): string {
+  const match = input.match(/.*?(?::\/\/|@)([^:\/]+)/);
+  if (match) {
+    return match[1];
+  }
+  return input;
+}


### PR DESCRIPTION
Parse hostname from given input. This allows for either real hostnames or urls to select a hostname from.

Closes #208