### PR TITLE
feat: add/remove assignees for gitlab

### DIFF
--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -1,6 +1,7 @@
 import { Git } from '../git';
 import { Tokens } from '../workflow-manager';
 import { Repository } from './repository';
+import { User } from './user';
 
 import { GithubClient } from './github/client';
 import { GitLabClient } from './gitlab/client';
@@ -25,6 +26,8 @@ export interface Client {
   name: string;
 
   getRepository(rid: string): Promise<Response<Repository>>;
+
+  getUserByUsername(username: string): Promise<Response<User>>;
 
 }
 

--- a/src/provider/github/client.ts
+++ b/src/provider/github/client.ts
@@ -5,6 +5,7 @@ import {
 
 import { GitHub, getClient } from './index';
 import { GithubRepository } from './repository';
+import { GithubUser } from './user';
 
 export class GithubClient implements Client {
 
@@ -34,4 +35,10 @@ export class GithubClient implements Client {
     };
   }
 
+  public async getUserByUsername(username: string): Promise<Response<GithubUser>> {
+    const response = await this.client.getUser(username);
+    return {
+      body: new GithubUser(this.client, response.body)
+    };
+  }
 }

--- a/src/provider/github/index.ts
+++ b/src/provider/github/index.ts
@@ -31,12 +31,19 @@ export interface GitHub {
   getPullRequestComments(owner: string, repo: string, number: number): Promise<GitHubResponse<PullRequestComment[]>>;
 
   editIssue(owner: string, repo: string, number: number, body: EditIssueBody): Promise<GitHubResponse<EditIssueBody>>;
+
+  getUser(username: string): Promise<GitHubResponse<UserResponse>>;
 }
 
 export interface GitHubResponse<T> {
   status: number;
   headers: {[name: string]: string[]};
   body: T;
+}
+
+export interface UserResponse {
+  id: number;
+  login: string;
 }
 
 export interface EditIssueBody {
@@ -231,7 +238,6 @@ namespace impl {
   }
 
   export class GitHubBlueprint implements GitHub {
-
     @Headers('Accept: application/vnd.github.polaris-preview')
     @Get('/repos/:owner/:repo')
     public getRepository(): any {/* */}
@@ -273,6 +279,8 @@ namespace impl {
     @Patch('/repos/:owner/:repo/issues/:number')
     public editIssue(): any {/* */}
 
+    @Get('/users/:username')
+    public getUser(): any {/* */}
   }
 
 }

--- a/src/provider/github/pull-request.ts
+++ b/src/provider/github/pull-request.ts
@@ -100,7 +100,7 @@ export class GithubPullRequest implements PullRequest {
       this.repository.repository,
       this.number,
       {
-        assignees: assignees.map(assignee => assignee.id)
+        assignees: assignees.map(assignee => assignee.username)
       }
     );
   }

--- a/src/provider/github/user.ts
+++ b/src/provider/github/user.ts
@@ -1,7 +1,23 @@
 import { User } from '../user';
+import { GitHub, UserResponse } from './index';
 
-export class GithubUser implements User<string> {
+export class GithubUser implements User {
 
-  public id: string;
+  private client: GitHub;
+
+  private struct: UserResponse;
+
+  public get id(): number {
+    return this.struct.id;
+  }
+
+  public get username(): string {
+    return this.struct.login;
+  }
+
+  constructor(client: GitHub, struct: UserResponse) {
+    this.client = client;
+    this.struct = struct;
+  }
 
 }

--- a/src/provider/gitlab/api.ts
+++ b/src/provider/gitlab/api.ts
@@ -4,7 +4,8 @@ import {
   IPretendRequestInterceptor,
   IPretendDecoder,
   Get,
-  Post
+  Post,
+  Put
 } from 'pretend';
 
 export interface GitLab {
@@ -12,13 +13,24 @@ export interface GitLab {
   getMergeRequests(id: string, parameters?: GetMergeRequestParameters): Promise<GitLabResponse<MergeRequest[]>>;
   getMergeRequest(id: string, mr_iid: number): Promise<GitLabResponse<MergeRequest>>;
   createMergeRequest(id: string, body: CreateMergeRequestBody): Promise<GitLabResponse<MergeRequest>>;
+  updateMergeRequest(id: string, mr_iid: number, body: UpdateMergeRequestBody): Promise<GitLabResponse<MergeRequest>>;
   getProjectIssues(id: string, body: ProjectIssuesBody): Promise<GitLabResponse<Issue[]>>;
+  searchUser(parameters?: SearchUsersParameters): Promise<GitLabResponse<UserResponse[]>>;
 }
 
 export interface GitLabResponse<T> {
   status: number;
   headers: {[name: string]: string[]};
   body: T;
+}
+
+export interface SearchUsersParameters {
+  username?: string;
+}
+
+export interface UserResponse {
+  id: number;
+  username: string;
 }
 
 export interface ProjectIssuesBody {
@@ -39,6 +51,16 @@ export interface CreateMergeRequestBody {
   title: string;
   description?: string;
   remove_source_branch?: boolean;
+}
+
+export interface UpdateMergeRequestBody {
+  target_branch?: string;
+  title?: string;
+  description?: string;
+  state_event?: 'close' | 'reopen';
+  assignee_id?: number;
+  remove_source_branch?: boolean;
+  squash?: boolean;
 }
 
 export interface GetMergeRequestParameters {
@@ -108,8 +130,8 @@ namespace impl {
 
   export function formEncoding(): IPretendRequestInterceptor {
     return request => {
-      if (request.options.method === 'POST') {
-        request.options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      if (request.options.method !== 'GET') {
+        request.options.headers.set('Content-Type', 'application/x-www-form-urlencoded');
         if (request.options.body) {
           const body = JSON.parse(request.options.body);
           const encodedBody = Object.keys(body)
@@ -143,16 +165,28 @@ namespace impl {
   }
 
   export class GitLabBlueprint implements GitLab {
+
+    @Get('/users', true)
+    public searchUser(): any {/* */}
+
     @Get('/projects/:id')
     public getProject(): any {/* */}
+
     @Get('/projects/:id/merge_requests', true)
     public getMergeRequests(): any {/* */}
+
     @Get('/projects/:id/merge_requests/:merge_request_iid')
     public getMergeRequest(): any {/* */}
+
     @Post('/projects/:id/merge_requests')
     public createMergeRequest(): any {/* */}
+
+    @Put('/projects/:id/merge_requests/:merge_request_iid')
+    public updateMergeRequest(): any {/* */}
+
     @Get('/projects/:id/issues')
     public getProjectIssues(): any {/* */}
+
   }
 
 }

--- a/src/provider/gitlab/client.ts
+++ b/src/provider/gitlab/client.ts
@@ -1,6 +1,7 @@
 import { Client, Response } from '../client';
 import { getClient, GitLab } from './api';
 import { GitLabRepository } from './repository';
+import { GitLabUser } from './user';
 
 export class GitLabClient implements Client {
 
@@ -20,6 +21,15 @@ export class GitLabClient implements Client {
     const response = (await this.client.getProject(encodeURIComponent(rid))).body;
     return {
       body: new GitLabRepository(this.client, response)
+    };
+  }
+
+  public async getUserByUsername(username: string): Promise<Response<GitLabUser>> {
+    const response = await this.client.searchUser({
+      username
+    });
+    return {
+      body: new GitLabUser(this.client, response.body[0])
     };
   }
 

--- a/src/provider/gitlab/merge-request.ts
+++ b/src/provider/gitlab/merge-request.ts
@@ -76,12 +76,25 @@ export class GitLabMergeRequest implements PullRequest {
     throw new Error('Method not implemented.');
   }
 
-  public async assign(_assignees: GitLabUser[]): Promise<void> {
-    throw new Error('Method not implemented.');
+  public async assign(assignees: GitLabUser[]): Promise<void> {
+    await this.client.updateMergeRequest(
+      encodeURIComponent(this.repository.pathWithNamespace),
+      this.mergeRequest.iid,
+      {
+        assignee_id: assignees[0].id
+      }
+    );
   }
 
   public async unassign(): Promise<void> {
-    throw new Error('Method not implemented.');
+    // note: assign to '0'
+    await this.client.updateMergeRequest(
+      encodeURIComponent(this.repository.pathWithNamespace),
+      this.mergeRequest.iid,
+      {
+        assignee_id: 0
+      }
+    );
   }
 
   public async requestReview(_body: RequestReviewBody): Promise<void> {

--- a/src/provider/gitlab/user.ts
+++ b/src/provider/gitlab/user.ts
@@ -1,5 +1,23 @@
 import { User } from '../user';
+import { GitLab, UserResponse } from './api';
 
-export class GitLabUser implements User<number> {
-  public id: number;
+export class GitLabUser implements User {
+
+  private client: GitLab;
+
+  private struct: UserResponse;
+
+  public get id(): number {
+    return this.struct.id;
+  }
+
+  public get username(): string {
+    return this.struct.username;
+  }
+
+  constructor(client: GitLab, struct: UserResponse) {
+    this.client = client;
+    this.struct = struct;
+  }
+
 }

--- a/src/provider/pull-request.ts
+++ b/src/provider/pull-request.ts
@@ -14,7 +14,7 @@ export interface PullRequest {
 
   getComments(): Promise<Response<Comment[]>>;
   merge(body: MergeBody): Promise<Response<MergeResult>>;
-  assign(assignees: User<any>[]): Promise<void>;
+  assign(assignees: User[]): Promise<void>;
   unassign(): Promise<void>;
   requestReview(body: RequestReviewBody): Promise<void>;
   cancelReview(body: CancelReviewBody): Promise<void>;

--- a/src/provider/user.ts
+++ b/src/provider/user.ts
@@ -1,3 +1,4 @@
-export interface User<ID> {
-  id: ID;
+export interface User {
+  id: number;
+  username: string;
 }

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -218,7 +218,8 @@ export class WorkflowManager {
   }
 
   public async addAssignee(pullRequest: PullRequest, name: string): Promise<void> {
-    await pullRequest.assign([{id: name}]);
+    const user = await this.provider.getUserByUsername(name);
+    await pullRequest.assign([user.body]);
   }
 
   public async removeAssignee(pullRequest: PullRequest): Promise<void> {


### PR DESCRIPTION
Add and remove assignees from merge requests in gitlab.
This includes a complete user api for github and gitlab.

Relates to #166