### PR TITLE
fix: parse response codes above 200

### DIFF
--- a/src/provider/github/index.ts
+++ b/src/provider/github/index.ts
@@ -246,7 +246,7 @@ namespace impl {
       return {
         status: response.status,
         headers,
-        body: response.status === 200 ? await response.json() : undefined
+        body: response.status >= 200 && response.status <= 300 ? await response.json() : undefined
       };
     };
   }

--- a/src/provider/gitlab/api.ts
+++ b/src/provider/gitlab/api.ts
@@ -177,7 +177,7 @@ namespace impl {
       return {
         status: response.status,
         headers,
-        body: response.status === 200 ? await response.json() : undefined
+        body: response.status >= 200 && response.status <= 300 ? await response.json() : undefined
       };
     };
   }


### PR DESCRIPTION
Reponse decoder should allow reponse codes between 200 and 300.