### PR TITLE
fix: unable to determine first commit

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -117,10 +117,14 @@ export class Git {
   }
 
   public async getFirstCommitOnBranch(branch: string, defaultBranch: string, uri: vscode.Uri): Promise<string> {
-    return (await this.execute(`git rev-list ^${defaultBranch} ${branch}`, uri)).stdout.trim().split('\n')[0];
+    const sha = (await this.execute(`git rev-list ^${defaultBranch} ${branch}`, uri)).stdout.trim().split('\n')[0];
+    if (!sha) {
+      return 'master';
+    }
+    return sha;
   }
 
-  public async getCommitBody(sha: string, uri: vscode.Uri): Promise<string> {
+  private async getCommitBody(sha: string, uri: vscode.Uri): Promise<string> {
     return (await this.execute(`git log --format=%b -n 1 ${sha}`, uri)).stdout.trim();
   }
 


### PR DESCRIPTION
If first commit on current branch could not be determined then master is taken as fallback.
This assumes that the commits to put into the pull request are commit on master and then a branch is created. It will be inaccurate to chose the correct title and body if there are multiple commits on master, since it is impossible to select the first commit (maybe it would be good to diff against origin/master and select the first commit between orgin/master and master in that case).

Closes #114 