### PR TITLE
feat: add allowUnsafeSSL config for self-signed certificates

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
           "default": false,
           "scope": "resource"
         },
+        "github.allowUnsafeSSL": {
+          "type": "boolean",
+          "description": "Allow SSL connnection with unauthorized self-signed certificates. Defaults to false",
+          "default": false,
+          "scope": "resource"
+        },
         "github.statusbar.command": {
           "type": [
             "string",
@@ -233,6 +239,7 @@
     "common-tags": "1.7.0",
     "conventional-changelog-lint-config-angular": "1.0.0",
     "execa": "^0.9.0",
+    "https": "1.0.0",
     "isomorphic-fetch": "2.2.1",
     "lru-cache": "^4.1.1",
     "pretend": "^1.2.1",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,6 +8,7 @@ export interface Configuration {
   upstream?: string;
   customPullRequestDescription: 'off' | 'singleLine' | 'gitEditor';
   autoPublish?: boolean;
+  allowUnsafeSSL?: boolean;
   statusBarCommand: string | null;
   statusbar: {
     refresh: number;

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Git } from '../git';
+import { getConfiguration } from '../helper';
 import { Tokens } from '../workflow-manager';
 import { Repository } from './repository';
 import { User } from './user';
@@ -13,14 +14,16 @@ export async function createClient(git: Git, tokens: Tokens, uri: vscode.Uri,
   const protocol = gitProtocol.startsWith('http') ? gitProtocol : 'https:';
   const hostname = await git.getGitHostname(uri);
   const tokenInfo = tokens[hostname];
+  const allowUnsafeSSL = !!getConfiguration('github', uri).allowUnsafeSSL;
   if (!tokenInfo) {
     throw new Error(`No token found for host ${hostname}`);
   }
   switch (tokenInfo.provider) {
     case 'github':
-      return new GithubClient(protocol, hostname, tokens[hostname].token, logger);
+      return new GithubClient(
+        protocol, hostname, tokens[hostname].token, logger, allowUnsafeSSL);
     case 'gitlab':
-      return new GitLabClient(protocol, hostname, tokens[hostname].token, logger);
+      return new GitLabClient(protocol, hostname, tokens[hostname].token, logger, allowUnsafeSSL);
     default:
       throw new Error(`Unknown git provider '${tokenInfo.provider}'`);
   }

--- a/src/provider/github/client.ts
+++ b/src/provider/github/client.ts
@@ -14,8 +14,9 @@ export class GithubClient implements Client {
 
   public name = 'GitHub Client';
 
-  constructor(protocol: string, hostname: string, token: string, logger: (message: string) => void) {
-    this.client = getClient(this.getApiEndpoint(protocol, hostname), token, logger);
+  constructor(protocol: string, hostname: string, token: string, logger: (message: string) => void,
+              allowUnsafeSSL = false) {
+    this.client = getClient(this.getApiEndpoint(protocol, hostname), token, logger, allowUnsafeSSL);
   }
 
   private getApiEndpoint(protocol: string, hostname: string): string {

--- a/src/provider/gitlab/client.ts
+++ b/src/provider/gitlab/client.ts
@@ -10,8 +10,9 @@ export class GitLabClient implements Client {
 
   public name = 'GitLab Client';
 
-  constructor(protocol: string, hostname: string, token: string, logger: (message: string) => void) {
-    this.client = getClient(this.getApiEndpoint(protocol, hostname), token, logger);
+  constructor(protocol: string, hostname: string, token: string, logger: (message: string) => void,
+              allowUnsafeSSL: boolean) {
+    this.client = getClient(this.getApiEndpoint(protocol, hostname), token, logger, allowUnsafeSSL);
   }
 
   private getApiEndpoint(protocol: string, hostname: string): string {


### PR DESCRIPTION
resolve #304 

Set `github.allowUnsafeSSL` to `true` in workspace settings to overcome https self-signed certificates problem.

