### PR TITLE
add configuration to set editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,12 @@
           "description": "GitLab setting to 'remove_source_branch' per MergeRequest.",
           "default": false,
           "scope": "resource"
-        }
+        },
+        "github.gitEditor": {
+          "type": "string",
+          "description": "The editor to use to edit messages for commits, pull requests etc. Defaults to the editor configured in `git.config.core.editor`.",
+          "scope": "window"
+        },
       }
     },
     "commands": [

--- a/src/git.ts
+++ b/src/git.ts
@@ -148,9 +148,15 @@ export class Git {
 
   private async getGitEditorPullRequestBody(uri: vscode.Uri): Promise<string> {
     const path = resolve(uri.fsPath, 'PR_EDITMSG');
+    const editorFromConfig = getConfiguration('github', uri).gitEditor;
 
-    const [editorName, ...params] = (await execa('git', ['config', '--get', 'core.editor'])).stdout.split(' ');
-    await execa(editorName, [...params, path]);
+    if (editorFromConfig) {
+      const [ gitEditor, ...geParams ] = editorFromConfig.split(' ');
+      yield execa(gitEditor, [...geParams, path]);
+    } else {
+      const [editorName, ...params] = (yield execa('git', ['config', '--get', 'core.editor'])).stdout.split(' ');
+      yield execa(editorName, [...params, path]);
+    }
 
     const fileContents = (await readFile(path)).toString();
 


### PR DESCRIPTION
This PR adds the possibility to configure what editor to use with the extension. If `github.gitEditor` is set, in my case I set it to `code -nw`, that editor will be used. If not it will fall back to using the editor set in `git.config.core.editor`.

Reasoning: My default editor for git messages is neovim, which doesn't really fit well with usage of this extension. VSCode doesn't seem to know how to open neovim to edit messages, and the process just stalls while it is waiting for the `PR_EDITMSG` file to be edited.