### PR TITLE
refactor: move manual input of pr title

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -194,23 +194,6 @@ export class Git {
     )).stdout.trim();
   }
 
-  public async getPullRequestTitle(
-    sha: string,
-    uri: vscode.Uri
-  ): Promise<string | undefined> {
-    const customTitle = getConfiguration('github', uri).customPullRequestTitle;
-
-    if (customTitle) {
-      return this.getSingleLinePullRequestTitle();
-    }
-
-    return this.getCommitMessage(sha, uri);
-  }
-
-  private async getSingleLinePullRequestTitle(): Promise<string | undefined> {
-    return vscode.window.showInputBox({ prompt: 'Pull request title' });
-  }
-
   public async getPullRequestBody(
     sha: string,
     uri: vscode.Uri


### PR DESCRIPTION
UI input do not belong into the git handler, therefore
the code was restructured to live in the workflow
handler.