### PR TITLE
feat: calculate git remote name

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
         },
         "github.remoteName": {
           "type": "string",
-          "description": "Defines the name of the git remote. Defaults to 'origin'.",
-          "default": "origin",
+          "description": "Defines the name of the git remote. Defaults to undefined which automatically tries to determine the proper remote name.",
           "scope": "resource"
         },
         "github.upstream": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,7 +4,7 @@ export interface Configuration {
   gitCommand?: string;
   preferedMergeMethod?: MergeMethod;
   refreshPullRequestStatus: number;
-  remoteName: string;
+  remoteName?: string;
   upstream?: string;
   customPullRequestTitle: boolean;
   customPullRequestDescription: 'off' | 'singleLine' | 'gitEditor';


### PR DESCRIPTION
Instead of use hardcoded 'origin' as remote name
first try to calculate it by looking up the
proper git refs.

Closes #407