### PR TITLE
feat: detect external pull request and allow to pull it

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -281,6 +281,22 @@ export class Git {
     }
   }
 
+  public async branch(
+    name: string,
+    base: string,
+    uri: vscode.Uri
+  ): Promise<void> {
+    await this.execute(`git checkout -b ${name} ${base}`, uri);
+  }
+
+  public async pullExternal(
+    repositoryUrl: string,
+    branch: string,
+    uri: vscode.Uri
+  ): Promise<void> {
+    await this.execute(`git pull ${repositoryUrl} ${branch}`, uri);
+  }
+
   private logAndShowError(e: Error): void {
     if (this.channel) {
       this.channel.appendLine(e.message);

--- a/src/provider/github/api.ts
+++ b/src/provider/github/api.ts
@@ -1,54 +1,130 @@
 import * as https from 'https';
 import * as LRUCache from 'lru-cache';
-import {Pretend, Get, Post, Put, Patch, Delete, Headers as Header, Interceptor, IPretendRequestInterceptor,
-  IPretendDecoder} from 'pretend';
+import {
+  Pretend,
+  Get,
+  Post,
+  Put,
+  Patch,
+  Delete,
+  Headers as Header,
+  Interceptor,
+  IPretendRequestInterceptor,
+  IPretendDecoder
+} from 'pretend';
 
 export interface GitHub {
-
   getRepositories(): Promise<GitHubResponse<GithubRepositoryStruct>>;
 
-  getRepository(owner: string, repo: string): Promise<GitHubResponse<GithubRepositoryStruct>>;
+  getRepository(
+    owner: string,
+    repo: string
+  ): Promise<GitHubResponse<GithubRepositoryStruct>>;
 
-  getPullRequest(owner: string, repo: string, number: number): Promise<GitHubResponse<PullRequestStruct>>;
+  getPullRequest(
+    owner: string,
+    repo: string,
+    number: number
+  ): Promise<GitHubResponse<PullRequestStruct>>;
 
-  listPullRequests(owner: string, repo: string, parameters?: ListPullRequestsParameters):
-    Promise<GitHubResponse<PullRequestStruct[]>>;
+  listPullRequests(
+    owner: string,
+    repo: string,
+    parameters?: ListPullRequestsParameters
+  ): Promise<GitHubResponse<PullRequestStruct[]>>;
 
-  createPullRequest(owner: string, repo: string, body: CreatePullRequestBody):
-    Promise<GitHubResponse<PullRequestStruct>>;
+  createPullRequest(
+    owner: string,
+    repo: string,
+    body: CreatePullRequestBody
+  ): Promise<GitHubResponse<PullRequestStruct>>;
 
-  updatePullRequest(owner: string, repo: string, number: number, body: UpdatePullRequestBody): Promise<void>;
+  updatePullRequest(
+    owner: string,
+    repo: string,
+    number: number,
+    body: UpdatePullRequestBody
+  ): Promise<void>;
 
-  getStatusForRef(owner: string, repo: string, ref: string): Promise<GitHubResponse<CombinedStatus>>;
+  getStatusForRef(
+    owner: string,
+    repo: string,
+    ref: string
+  ): Promise<GitHubResponse<CombinedStatus>>;
 
-  mergePullRequest(owner: string, repo: string, number: number, body: Merge): Promise<GitHubResponse<MergeResult>>;
+  mergePullRequest(
+    owner: string,
+    repo: string,
+    number: number,
+    body: Merge
+  ): Promise<GitHubResponse<MergeResult>>;
 
-  addAssignees(owner: string, repo: string, numer: number, body: Assignees): Promise<void>;
+  addAssignees(
+    owner: string,
+    repo: string,
+    numer: number,
+    body: Assignees
+  ): Promise<void>;
 
-  removeAssignees(owner: string, repo: string, numer: number, body: Assignees): Promise<void>;
+  removeAssignees(
+    owner: string,
+    repo: string,
+    numer: number,
+    body: Assignees
+  ): Promise<void>;
 
-  requestReview(owner: string, repo: string, numer: number, body: Reviewers): Promise<void>;
+  requestReview(
+    owner: string,
+    repo: string,
+    numer: number,
+    body: Reviewers
+  ): Promise<void>;
 
-  deleteReviewRequest(owner: string, repo: string, numer: number, body: Reviewers): Promise<void>;
+  deleteReviewRequest(
+    owner: string,
+    repo: string,
+    numer: number,
+    body: Reviewers
+  ): Promise<void>;
 
-  issues(owner: string, repo: string, parameters?: IssuesParameters): Promise<GitHubResponse<Issue[]>>;
+  issues(
+    owner: string,
+    repo: string,
+    parameters?: IssuesParameters
+  ): Promise<GitHubResponse<Issue[]>>;
 
-  getPullRequestComments(owner: string, repo: string, number: number): Promise<GitHubResponse<PullRequestComment[]>>;
+  getPullRequestComments(
+    owner: string,
+    repo: string,
+    number: number
+  ): Promise<GitHubResponse<PullRequestComment[]>>;
 
-  editIssue(owner: string, repo: string, number: number, body: EditIssueBody): Promise<GitHubResponse<EditIssueBody>>;
+  editIssue(
+    owner: string,
+    repo: string,
+    number: number,
+    body: EditIssueBody
+  ): Promise<GitHubResponse<EditIssueBody>>;
 
   getAuthenticatedUser(): Promise<GitHubResponse<UserResponse>>;
 
   getUser(username: string): Promise<GitHubResponse<UserResponse>>;
 
-  listAssignees(owner: string, repo: string): Promise<GitHubResponse<UserResponse[]>>;
+  listAssignees(
+    owner: string,
+    repo: string
+  ): Promise<GitHubResponse<UserResponse[]>>;
 
-  getIssueComments(owner: string, repo: string, number: number): Promise<GitHubResponse<IssueComment[]>>;
+  getIssueComments(
+    owner: string,
+    repo: string,
+    number: number
+  ): Promise<GitHubResponse<IssueComment[]>>;
 }
 
 export interface GitHubResponse<T> {
   status: number;
-  headers: {[name: string]: string[]};
+  headers: { [name: string]: string[] };
   body: T;
 }
 
@@ -95,7 +171,7 @@ export interface Issue {
 }
 
 export interface IssuesParameters {
-  milestone?: string|number;
+  milestone?: string | number;
   state?: 'closed' | 'all' | 'open';
   assignee?: string;
   sort?: 'created' | 'updated' | 'comments';
@@ -121,6 +197,7 @@ export interface GithubRepositoryStruct {
   allow_squash_merge?: boolean;
   allow_merge_commit?: boolean;
   html_url: string;
+  clone_url: string;
   parent?: GithubRepositoryStruct;
 }
 
@@ -173,18 +250,23 @@ export interface PullRequestStruct {
   head: {
     label: string;
     ref: string;
+    repo: GithubRepositoryStruct;
   };
   base: {
     label: string;
     ref: string;
+    repo: GithubRepositoryStruct;
   };
-  mergeable?: boolean|null;
+  mergeable?: boolean | null;
 }
 
-export function getClient(endpoint: string, token: string, logger: (message: string) => void,
-                          allowUnsafeSSL = false): GitHub {
-  return Pretend
-    .builder()
+export function getClient(
+  endpoint: string,
+  token: string,
+  logger: (message: string) => void,
+  allowUnsafeSSL = false
+): GitHub {
+  return Pretend.builder()
     .interceptor(impl.githubCache())
     .requestInterceptor(impl.githubTokenAuthenticator(token))
     .requestInterceptor(impl.githubHttpsAgent(!allowUnsafeSSL))
@@ -194,7 +276,6 @@ export function getClient(endpoint: string, token: string, logger: (message: str
 }
 
 export class GitHubError extends Error {
-
   public readonly response: Response;
 
   constructor(message: string, response: Response) {
@@ -204,9 +285,8 @@ export class GitHubError extends Error {
 }
 
 namespace impl {
-
   export function logger(logger: (message: string) => void): Interceptor {
-    return async(chain, request) => {
+    return async (chain, request) => {
       try {
         logger(`${request.options.method} ${request.url}`);
         // console.log('github-request: ', request);
@@ -224,8 +304,8 @@ namespace impl {
 
   export function githubCache(): Interceptor {
     // cache at most 100 requests
-    const cache = LRUCache<string, {etag: string, response: any}>(100);
-    return async(chain, request) => {
+    const cache = LRUCache<string, { etag: string; response: any }>(100);
+    return async (chain, request) => {
       const entry = cache.get(request.url);
       if (entry) {
         // when we have a cache hit, send etag
@@ -246,7 +326,9 @@ namespace impl {
     };
   }
 
-  export function githubTokenAuthenticator(token: string): IPretendRequestInterceptor {
+  export function githubTokenAuthenticator(
+    token: string
+  ): IPretendRequestInterceptor {
     return request => {
       request.options.headers = new Headers(request.options.headers);
       request.options.headers.set('Authorization', `token ${token}`);
@@ -254,7 +336,9 @@ namespace impl {
     };
   }
 
-  export function githubHttpsAgent(rejectUnauthorized: boolean): IPretendRequestInterceptor {
+  export function githubHttpsAgent(
+    rejectUnauthorized: boolean
+  ): IPretendRequestInterceptor {
     return request => {
       if (!request.url.startsWith('https://')) {
         return request;
@@ -268,7 +352,10 @@ namespace impl {
     return async response => {
       if (response.status >= 400) {
         const body = await response.json();
-        throw new GitHubError(`${body.message || response.statusText}`, response);
+        throw new GitHubError(
+          `${body.message || response.statusText}`,
+          response
+        );
       }
       const headers = {};
       response.headers.forEach((value: string, index: number) => {
@@ -277,71 +364,110 @@ namespace impl {
       return {
         status: response.status,
         headers,
-        body: response.status >= 200 && response.status <= 300 ? await response.json() : undefined
+        body:
+          response.status >= 200 && response.status <= 300
+            ? await response.json()
+            : undefined
       };
     };
   }
 
   export class GitHubBlueprint implements GitHub {
     @Get('/user')
-    public getAuthenticatedUser(): any {/* */}
+    public getAuthenticatedUser(): any {
+      /* */
+    }
 
     @Get('/user/repos')
-    public getRepositories(): any {/* */}
+    public getRepositories(): any {
+      /* */
+    }
 
     @Header('Accept: application/vnd.github.polaris-preview')
     @Get('/repos/:owner/:repo')
-    public getRepository(): any {/* */}
+    public getRepository(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/pulls/:number')
-    public getPullRequest(): any {/* */}
+    public getPullRequest(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/pulls', true)
-    public listPullRequests(): any {/* */}
+    public listPullRequests(): any {
+      /* */
+    }
 
     @Post('/repos/:owner/:repo/pulls')
-    public createPullRequest(): any {/* */}
+    public createPullRequest(): any {
+      /* */
+    }
 
     @Patch('/repos/:owner/:repo/pulls/:number')
-    public updatePullRequest(): any {/* */}
+    public updatePullRequest(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/commits/:ref/status')
-    public getStatusForRef(): any {/* */}
+    public getStatusForRef(): any {
+      /* */
+    }
 
     @Header('Accept: application/vnd.github.polaris-preview+json')
     @Put('/repos/:owner/:repo/pulls/:number/merge')
-    public mergePullRequest(): any {/* */}
+    public mergePullRequest(): any {
+      /* */
+    }
 
     @Post('/repos/:owner/:repo/issues/:number/assignees')
-    public addAssignees(): any {/* */}
+    public addAssignees(): any {
+      /* */
+    }
 
     @Delete('/repos/:owner/:repo/issues/:number/assignees', true)
-    public removeAssignees(): any {/* */}
+    public removeAssignees(): any {
+      /* */
+    }
 
     @Post('/repos/:owner/:repo/pulls/:number/requested_reviewers')
-    public requestReview(): any {/* */}
+    public requestReview(): any {
+      /* */
+    }
 
     @Delete('/repos/:owner/:repo/pulls/:number/requested_reviewers', true)
-    public deleteReviewRequest(): any {/* */}
+    public deleteReviewRequest(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/issues', true)
-    public issues(): any {/* */}
+    public issues(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/pulls/:number/comments')
-    public getPullRequestComments(): any {/* */}
+    public getPullRequestComments(): any {
+      /* */
+    }
 
     @Patch('/repos/:owner/:repo/issues/:number')
-    public editIssue(): any {/* */}
+    public editIssue(): any {
+      /* */
+    }
 
     @Get('/users/:username')
-    public getUser(): any {/* */}
+    public getUser(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/assignees')
-    public listAssignees(): any {/* */}
+    public listAssignees(): any {
+      /* */
+    }
 
     @Get('/repos/:owner/:repo/issues/:number/comments')
-    public getIssueComments(): any {/* */}
-
+    public getIssueComments(): any {
+      /* */
+    }
   }
-
 }

--- a/src/provider/github/client.ts
+++ b/src/provider/github/client.ts
@@ -1,24 +1,30 @@
 import * as vscode from 'vscode';
-import {
-  Client,
-  Response
-} from '../client';
+import { Client, Response } from '../client';
 
 import { GitHub, getClient, GithubRepositoryStruct } from './api';
 import { GithubRepository } from './repository';
 import { GithubUser } from './user';
 
 export class GithubClient implements Client {
-
   private readonly client: GitHub;
 
   public name = 'GitHub Client';
 
   private readonly repositories = new Map<string, GithubRepositoryStruct>();
 
-  constructor(protocol: string, hostname: string, token: string, logger: (message: string) => void,
-              allowUnsafeSSL = false) {
-    this.client = getClient(this.getApiEndpoint(protocol, hostname), token, logger, allowUnsafeSSL);
+  constructor(
+    protocol: string,
+    hostname: string,
+    token: string,
+    logger: (message: string) => void,
+    allowUnsafeSSL = false
+  ) {
+    this.client = getClient(
+      this.getApiEndpoint(protocol, hostname),
+      token,
+      logger,
+      allowUnsafeSSL
+    );
   }
 
   private getApiEndpoint(protocol: string, hostname: string): string {
@@ -38,27 +44,44 @@ export class GithubClient implements Client {
   public async getCurrentUser(): Promise<Response<GithubUser>> {
     const response = await this.client.getAuthenticatedUser();
     return {
-      body: new  GithubUser(this.client, response.body)
+      body: new GithubUser(this.client, response.body)
     };
   }
 
-  public async getRepository(uri: vscode.Uri, rid: string): Promise<Response<GithubRepository>> {
+  public async getRepository(
+    uri: vscode.Uri,
+    rid: string
+  ): Promise<Response<GithubRepository>> {
     const [owner, repository] = rid.split('/');
     const cacheKey = `${uri.toString()}$$${rid}`;
     const cacheHit = this.repositories.get(cacheKey);
     if (cacheHit) {
       return {
-        body: new GithubRepository(uri, this.client, owner, repository, cacheHit)
+        body: new GithubRepository(
+          uri,
+          this.client,
+          owner,
+          repository,
+          cacheHit
+        )
       };
     }
     const response = await this.client.getRepository(owner, repository);
     this.repositories.set(cacheKey, response.body);
     return {
-      body: new GithubRepository(uri, this.client, owner, repository, response.body)
+      body: new GithubRepository(
+        uri,
+        this.client,
+        owner,
+        repository,
+        response.body
+      )
     };
   }
 
-  public async getUserByUsername(username: string): Promise<Response<GithubUser>> {
+  public async getUserByUsername(
+    username: string
+  ): Promise<Response<GithubUser>> {
     const response = await this.client.getUser(username);
     return {
       body: new GithubUser(this.client, response.body)

--- a/src/provider/github/pull-request.ts
+++ b/src/provider/github/pull-request.ts
@@ -13,7 +13,6 @@ import { GithubRepository } from './repository';
 import { GithubUser } from './user';
 
 export class GithubPullRequest implements PullRequest {
-
   private readonly client: GitHub;
   private readonly repository: GithubRepository;
   private readonly struct: PullRequestStruct;
@@ -54,7 +53,35 @@ export class GithubPullRequest implements PullRequest {
     return this.struct.mergeable;
   }
 
-  constructor(client: GitHub, repository: GithubRepository, struct: PullRequestStruct) {
+  get head(): { repository: GithubRepository } {
+    return {
+      repository: new GithubRepository(
+        undefined,
+        this.client,
+        this.struct.head.repo.owner.login,
+        this.struct.head.repo.name,
+        this.struct.head.repo
+      )
+    };
+  }
+
+  get base(): { repository: GithubRepository } {
+    return {
+      repository: new GithubRepository(
+        undefined,
+        this.client,
+        this.struct.base.repo.owner.login,
+        this.struct.base.repo.name,
+        this.struct.base.repo
+      )
+    };
+  }
+
+  constructor(
+    client: GitHub,
+    repository: GithubRepository,
+    struct: PullRequestStruct
+  ) {
     this.client = client;
     this.repository = repository;
     this.struct = struct;

--- a/src/provider/github/repository.ts
+++ b/src/provider/github/repository.ts
@@ -13,7 +13,6 @@ import { GithubPullRequest } from './pull-request';
 import { GithubUser } from './user';
 
 export class GithubRepository implements Repository {
-
   public readonly uri: vscode.Uri | undefined;
 
   private readonly client: GitHub;
@@ -64,13 +63,17 @@ export class GithubRepository implements Repository {
     return this.struct.html_url;
   }
 
+  public get cloneUrl(): string {
+    return this.struct.clone_url;
+  }
+
   constructor(
-      uri: vscode.Uri | undefined,
-      client: GitHub,
-      owner: string,
-      repository: string,
-      struct: GithubRepositoryStruct
-    ) {
+    uri: vscode.Uri | undefined,
+    client: GitHub,
+    owner: string,
+    repository: string,
+    struct: GithubRepositoryStruct
+  ) {
     this.uri = uri;
     this.client = client;
     this.owner = owner;
@@ -78,38 +81,63 @@ export class GithubRepository implements Repository {
     this.struct = struct;
   }
 
-  public async getPullRequests(parameters?: ListPullRequestsParameters | undefined):
-      Promise<Response<GithubPullRequest[]>> {
-    const response = await this.client.listPullRequests(this.owner, this.repository, parameters);
-    const body = response.body.map(pr => new GithubPullRequest(this.client, this, pr));
+  public async getPullRequests(
+    parameters?: ListPullRequestsParameters | undefined
+  ): Promise<Response<GithubPullRequest[]>> {
+    const response = await this.client.listPullRequests(
+      this.owner,
+      this.repository,
+      parameters
+    );
+    const body = response.body.map(
+      pr => new GithubPullRequest(this.client, this, pr)
+    );
     return {
       body
     };
   }
 
-  public async getPullRequest(id: number): Promise<Response<GithubPullRequest>> {
-    const response = await this.client.getPullRequest(this.owner, this.repository, id);
+  public async getPullRequest(
+    id: number
+  ): Promise<Response<GithubPullRequest>> {
+    const response = await this.client.getPullRequest(
+      this.owner,
+      this.repository,
+      id
+    );
     return {
       body: new GithubPullRequest(this.client, this, response.body)
     };
   }
 
-  public async createPullRequest(body: CreatePullRequestBody): Promise<Response<GithubPullRequest>> {
-    const result = await this.client.createPullRequest(this.owner, this.repository, {
-      head: `${this.owner}:${body.sourceBranch}`,
-      base: `${body.targetBranch}`,
-      title: body.title,
-      body: body.body
-    });
+  public async createPullRequest(
+    body: CreatePullRequestBody
+  ): Promise<Response<GithubPullRequest>> {
+    const result = await this.client.createPullRequest(
+      this.owner,
+      this.repository,
+      {
+        head: `${this.owner}:${body.sourceBranch}`,
+        base: `${body.targetBranch}`,
+        title: body.title,
+        body: body.body
+      }
+    );
     const expr = new RegExp(`https?://[^/:]+/repos/[^/]+/[^/]+/pulls/([0-9]+)`);
     const number = expr.exec(result.headers['location'][0]) as RegExpMatchArray;
-    const response = await this.client.getPullRequest(this.owner, this.repository, parseInt(number[1], 10));
+    const response = await this.client.getPullRequest(
+      this.owner,
+      this.repository,
+      parseInt(number[1], 10)
+    );
     return {
       body: new GithubPullRequest(this.client, this, response.body)
     };
   }
 
-  public async getIssues(parameters: IssuesParameters = {}): Promise<Response<Issue[]>> {
+  public async getIssues(
+    parameters: IssuesParameters = {}
+  ): Promise<Response<Issue[]>> {
     const response = await this.client.issues(this.owner, this.repository, {
       direction: parameters.direction,
       sort: parameters.sort,

--- a/src/provider/gitlab/client.ts
+++ b/src/provider/gitlab/client.ts
@@ -5,14 +5,23 @@ import { GitLabRepository } from './repository';
 import { GitLabUser } from './user';
 
 export class GitLabClient implements Client {
-
   private readonly client: GitLab;
 
   public name = 'GitLab Client';
 
-  constructor(protocol: string, hostname: string, token: string, logger: (message: string) => void,
-              allowUnsafeSSL: boolean) {
-    this.client = getClient(this.getApiEndpoint(protocol, hostname), token, logger, allowUnsafeSSL);
+  constructor(
+    protocol: string,
+    hostname: string,
+    token: string,
+    logger: (message: string) => void,
+    allowUnsafeSSL: boolean
+  ) {
+    this.client = getClient(
+      this.getApiEndpoint(protocol, hostname),
+      token,
+      logger,
+      allowUnsafeSSL
+    );
   }
 
   private getApiEndpoint(protocol: string, hostname: string): string {
@@ -30,14 +39,20 @@ export class GitLabClient implements Client {
     };
   }
 
-  public async getRepository(uri: vscode.Uri, rid: string): Promise<Response<GitLabRepository>> {
-    const response = (await this.client.getProject(encodeURIComponent(rid))).body;
+  public async getRepository(
+    uri: vscode.Uri,
+    rid: string
+  ): Promise<Response<GitLabRepository>> {
+    const response = (await this.client.getProject(encodeURIComponent(rid)))
+      .body;
     return {
       body: new GitLabRepository(uri, this.client, response)
     };
   }
 
-  public async getUserByUsername(username: string): Promise<Response<GitLabUser>> {
+  public async getUserByUsername(
+    username: string
+  ): Promise<Response<GitLabUser>> {
     const response = await this.client.searchUser({
       username
     });
@@ -45,5 +60,4 @@ export class GitLabClient implements Client {
       body: new GitLabUser(this.client, response.body[0])
     };
   }
-
 }

--- a/src/provider/gitlab/merge-request.ts
+++ b/src/provider/gitlab/merge-request.ts
@@ -14,7 +14,6 @@ import { GitLabRepository } from './repository';
 import { GitLabUser } from './user';
 
 export class GitLabMergeRequest implements PullRequest {
-
   private readonly client: GitLab;
   private readonly repository: GitLabRepository;
   private readonly mergeRequest: MergeRequest;
@@ -64,7 +63,19 @@ export class GitLabMergeRequest implements PullRequest {
     }
   }
 
-  constructor(client: GitLab, repository: GitLabRepository, mergeRequest: MergeRequest) {
+  public get head(): never {
+    throw new Error('not implemented');
+  }
+
+  public get base(): never {
+    throw new Error('not implemented');
+  }
+
+  constructor(
+    client: GitLab,
+    repository: GitLabRepository,
+    mergeRequest: MergeRequest
+  ) {
     this.client = client;
     this.repository = repository;
     this.mergeRequest = mergeRequest;
@@ -79,7 +90,9 @@ export class GitLabMergeRequest implements PullRequest {
       gitlabBody.description = body.body;
     }
     if (body.state) {
-      const mapState = (state: UpdateBody['state']): UpdateMergeRequestBody['state_event'] => {
+      const mapState = (
+        state: UpdateBody['state']
+      ): UpdateMergeRequestBody['state_event'] => {
         switch (state) {
           case 'open':
             return 'reopen';
@@ -87,7 +100,7 @@ export class GitLabMergeRequest implements PullRequest {
             return 'close';
           default:
             return undefined;
-          }
+        }
       };
       gitlabBody.state_event = mapState(body.state);
     }

--- a/src/provider/gitlab/repository.ts
+++ b/src/provider/gitlab/repository.ts
@@ -20,7 +20,6 @@ import { GitLabMergeRequest } from './merge-request';
 import { GitLabUser } from './user';
 
 export class GitLabRepository implements Repository {
-
   public readonly uri: vscode.Uri | undefined;
 
   private readonly client: GitLab;
@@ -58,15 +57,22 @@ export class GitLabRepository implements Repository {
     return this.project.web_url;
   }
 
+  public get cloneUrl(): string {
+    throw new Error('not implemented');
+  }
+
   constructor(uri: vscode.Uri | undefined, client: GitLab, project: Project) {
     this.uri = uri;
     this.client = client;
     this.project = project;
   }
 
-  public async getPullRequests(parameters: ListPullRequestsParameters = {}):
-      Promise<Response<GitLabMergeRequest[]>> {
-    function getState(state: ListPullRequestsParameters['state']): GetMergeRequestParameters['state'] {
+  public async getPullRequests(
+    parameters: ListPullRequestsParameters = {}
+  ): Promise<Response<GitLabMergeRequest[]>> {
+    function getState(
+      state: ListPullRequestsParameters['state']
+    ): GetMergeRequestParameters['state'] {
       switch (state) {
         case 'open':
           return 'opened';
@@ -76,7 +82,9 @@ export class GitLabRepository implements Repository {
           return undefined;
       }
     }
-    function getOrderBy(orderBy: ListPullRequestsParameters['sort']): GetMergeRequestParameters['order_by'] {
+    function getOrderBy(
+      orderBy: ListPullRequestsParameters['sort']
+    ): GetMergeRequestParameters['order_by'] {
       switch (orderBy) {
         case 'created':
           return 'created_at';
@@ -97,13 +105,20 @@ export class GitLabRepository implements Repository {
     if (parameters.direction) {
       params.sort = parameters.direction;
     }
-    const respose = await this.client.getMergeRequests(encodeURIComponent(this.project.path_with_namespace), params);
+    const respose = await this.client.getMergeRequests(
+      encodeURIComponent(this.project.path_with_namespace),
+      params
+    );
     return {
-      body: respose.body.map(mergeRequest => new GitLabMergeRequest(this.client, this, mergeRequest))
+      body: respose.body.map(
+        mergeRequest => new GitLabMergeRequest(this.client, this, mergeRequest)
+      )
     };
   }
 
-  public async getPullRequest(id: number): Promise<Response<GitLabMergeRequest>> {
+  public async getPullRequest(
+    id: number
+  ): Promise<Response<GitLabMergeRequest>> {
     const response = await this.client.getMergeRequest(
       encodeURIComponent(this.project.path_with_namespace),
       id
@@ -113,18 +128,20 @@ export class GitLabRepository implements Repository {
     };
   }
 
-  public async createPullRequest(body: CreatePullRequestBody): Promise<Response<GitLabMergeRequest>> {
+  public async createPullRequest(
+    body: CreatePullRequestBody
+  ): Promise<Response<GitLabMergeRequest>> {
     const removeSourceBranch = this.uri
       ? getConfiguration('gitlab', this.uri).removeSourceBranch
       : false;
-    const gitlabBody: CreateMergeRequestBody =  {
+    const gitlabBody: CreateMergeRequestBody = {
       source_branch: body.sourceBranch,
       target_branch: body.targetBranch,
       title: body.title,
       remove_source_branch: removeSourceBranch
     };
     if (body.body) {
-     gitlabBody.description = body.body;
+      gitlabBody.description = body.body;
     }
     const response = await this.client.createMergeRequest(
       encodeURIComponent(this.project.path_with_namespace),
@@ -135,8 +152,12 @@ export class GitLabRepository implements Repository {
     };
   }
 
-  public async getIssues(parameters?: IssuesParameters | undefined): Promise<Response<Issue[]>> {
-    function getState(state: IssuesParameters['state']): ProjectIssuesBody['state'] {
+  public async getIssues(
+    parameters?: IssuesParameters | undefined
+  ): Promise<Response<Issue[]>> {
+    function getState(
+      state: IssuesParameters['state']
+    ): ProjectIssuesBody['state'] {
       switch (state) {
         case 'open':
           return 'opened';
@@ -145,7 +166,9 @@ export class GitLabRepository implements Repository {
       }
       return undefined;
     }
-    function getOrderBy(orderBy: IssuesParameters['sort']): ProjectIssuesBody['order_by'] {
+    function getOrderBy(
+      orderBy: IssuesParameters['sort']
+    ): ProjectIssuesBody['order_by'] {
       switch (orderBy) {
         case 'created':
           return 'created_at';
@@ -173,7 +196,9 @@ export class GitLabRepository implements Repository {
       body
     );
     return {
-      body: response.body.map(issue => new GitLabIssue(this.client, this, issue))
+      body: response.body.map(
+        issue => new GitLabIssue(this.client, this, issue)
+      )
     };
   }
 

--- a/src/provider/pull-request.ts
+++ b/src/provider/pull-request.ts
@@ -1,4 +1,5 @@
 import { Response } from './client';
+import { Repository } from './repository';
 import { User } from './user';
 
 export interface PullRequest {
@@ -10,7 +11,13 @@ export interface PullRequest {
   url: string;
   sourceBranch: string;
   targetBranch: string;
-  mergeable?: boolean|null;
+  mergeable?: boolean | null;
+  head: {
+    repository: Repository;
+  };
+  base: {
+    repository: Repository;
+  };
 
   update(body: UpdateBody): Promise<void>;
   getComments(): Promise<Response<Comment[]>>;

--- a/src/provider/repository.ts
+++ b/src/provider/repository.ts
@@ -13,10 +13,15 @@ export interface Repository {
   allowRebaseCommits: boolean;
   parent: Repository | undefined;
   url: string;
+  cloneUrl: string;
 
-  getPullRequests(parameters?: ListPullRequestsParameters): Promise<Response<PullRequest[]>>;
+  getPullRequests(
+    parameters?: ListPullRequestsParameters
+  ): Promise<Response<PullRequest[]>>;
   getPullRequest(id: number): Promise<Response<PullRequest>>;
-  createPullRequest(body: CreatePullRequestBody): Promise<Response<PullRequest>>;
+  createPullRequest(
+    body: CreatePullRequestBody
+  ): Promise<Response<PullRequest>>;
   getIssues(parameters?: IssuesParameters): Promise<Response<Issue[]>>;
   getUsers(): Promise<Response<User[]>>;
 }


### PR DESCRIPTION
This case enables external pull requests (from forked repo
without write permission) to be checked out for review.
For security reasons the user needs to confirm to pull
external code (it could be harmful to pull code if watch
tasks are running over external code).

Closes #258