### PR TITLE
fix: create instance of LRUCache properly

### DIFF
--- a/src/provider/github/api.ts
+++ b/src/provider/github/api.ts
@@ -304,7 +304,7 @@ namespace impl {
 
   export function githubCache(): Interceptor {
     // cache at most 100 requests
-    const cache = LRUCache<string, { etag: string; response: any }>(100);
+    const cache = new LRUCache<string, { etag: string; response: any }>(100);
     return async (chain, request) => {
       const entry = cache.get(request.url);
       if (entry) {


### PR DESCRIPTION
This PR adds `new` keyword explicitly on `LRUCache` instance creation.
This is done because in some environments implicit instance creation fails with following error:
```
Error: Class constructor LRUCache cannot be invoked without 'new'
```