### PR TITLE
chore: use node 10 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '7'
+  - '10'
 os:
   # - osx # still too slow
   - linux
@@ -16,7 +16,7 @@ branches:
     - master
 cache:
   directories:
-  - node_modules
+    - node_modules
 notifications:
   email:
     on_success: never
@@ -25,9 +25,9 @@ env:
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
+    export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+    sh -e /etc/init.d/xvfb start;
+    sleep 3;
     fi
   - mkdir /tmp/test-workspace && cd /tmp/test-workspace && git init && cd -
 install:


### PR DESCRIPTION
Since vscode itself uses node 10 and fails to install in a node 7
environment we need to update.