### PR TITLE
fix: Browse command with Multi-Line selection

### DIFF
--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -68,9 +68,9 @@ export class BrowseCurrentFile extends TokenCommand {
       }
       const root = await this.git.getGitRoot(folder.uri);
       const file = editor.document.fileName.substring(root.length);
-      const line = editor.selection.active.line;
+      const startLine = editor.selection.start.line;
       const endLine = editor.selection.end.line;
-      const uri = vscode.Uri.parse(await this.workflowManager.getGithubFileUrl(folder.uri, file, line, endLine));
+      const uri = vscode.Uri.parse(await this.workflowManager.getGithubFileUrl(folder.uri, file, startLine, endLine));
       vscode.commands.executeCommand('vscode.open', uri);
     }
   }


### PR DESCRIPTION
This PR uses the start line of the selection, rather than the current line, in the URL generated for the `Browse current file` command. This change is because previously this would only work as expected for multi line selections if the selection was made bottom to top (so `endLine` was the start of the selection, and `line` was the end of the selection) but not top to bottom (where `line` and `endLine` would be the same.