### PR TITLE
Fix remote regex for zsh

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -49,7 +49,7 @@ export class Git {
 
   private async getRemoteNames(uri: vscode.Uri): Promise<string[]> {
     const remotes = (await this.execute(
-      `git config --local --get-regexp ^remote.*.url`,
+      `git config --local --get-regexp "^remote.*.url"`,
       uri
     )).stdout.trim();
     return remotes


### PR DESCRIPTION
My remote is `origin`.

So the first command `git config --local --get remote.upstream.url` doesn't return anything (because I don't have a remote named `upstream`).

After that, the second command `git config --local --get-regexp ^remote.*.url` should find my remote... but it fails.

If I try to run it in zsh, I get:

```
zsh: no matches found: ^remote.*.url
```

I need to surround the regex with quotation marks so that zsh does not interpret the regex.