### PR TITLE
Revert #774 and change user message

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -49,7 +49,7 @@ export class Git {
 
   private async getRemoteNames(uri: vscode.Uri): Promise<string[]> {
     const remotes = (await this.execute(
-      `git config --local --get-regexp "^remote.*.url"`,
+      `git config --local --get-regexp ^remote.*.url`,
       uri
     )).stdout.trim();
     return remotes
@@ -142,7 +142,7 @@ export class Git {
         this.logAndShowError(e);
 
         this.channel.appendLine(
-          '\n\nYour configuration contains an invalid remoteName. You should probably use one of these:\n'
+          '\n\nYour configuration contains an invalid remoteName. Consider setting the `github.remoteName` setting with one of these:\n'
         );
         this.channel.appendLine(remotes.join('\n') + '\n');
       }


### PR DESCRIPTION
**TLDR:** I'm afraid what I did in #774 was useless and, worst, adds a bug. So I'm here to revert this.

It was a misunderstanding of mine. I didn't know the `github.remoteName` setting. And when I saw the error I was mentionning in #774, I directly tried the exact same command in my zsh shell, and it didn't work. So I thought zsh was the problem and it indeed worked in zsh when I added quotation marks around the regex. But `execa` does not use zsh under the hood, so this is useless.

I just did a test with basic JavaScript using `execa` and adding quotation marks make the command crash!

```js
const execa = require('execa');

async function execute(cmd) {
    const [git, ...args] = cmd.split(' ');
    return execa(git, args);
}

async function getRemoteNames() {
    const remotes = (await execute(
        `git config --local --get-regexp "^remote.*.url"`
    )).stdout.trim();
    return remotes
        .split('\n')
        .map(line => new RegExp('^remote.([^.]+).url.*').exec(line))
        .map(match => match && match[1])
        .filter(name => Boolean(name));
}

getRemoteNames().then(res => console.log(res));
```

The thing is, I had not tested the quick fix I made, and I should have.
And when I used the new version you published after my change, I hadn't had any bug anymore, so I thought it was good.

The real issue was me and my `github.remoteName` setting, so I edited the user message to assist the user more.