### PR TITLE
Allow overriding line separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,12 @@
           "default": false,
           "scope": "resource"
         },
+        "github.urlLineSeparator": {
+          "type": "string",
+          "description": "Overrides the default line separator when constructing URLs. Defaults to ':'.",
+          "scope": "window",
+          "default": ":"
+        },
         "github.statusbar.enabled": {
           "type": "boolean",
           "description": "True if the statusbar integration should be enabled. Defaults to true",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -11,6 +11,7 @@ export interface Configuration {
   autoPublish?: boolean;
   allowUnsafeSSL?: boolean;
   statusBarCommand: string | null;
+  urlLineSeparator: string;
   statusbar: {
     enabled: boolean;
     refresh: number;

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -340,8 +340,9 @@ export class WorkflowManager {
     const [owner, repo] = await this.git.getGitProviderOwnerAndRepository(uri);
     const branch = await this.git.getCurrentBranch(uri);
     const currentFile = file.replace(/^\//, '');
+    const lineSeparator = getConfiguration('github', uri).urlLineSeparator
     return `https://${hostname}/${owner}/${repo}/blob/${branch}/${currentFile}#L${line +
-      1}:L${endLine + 1}`;
+      1}${lineSeparator}L${endLine + 1}`;
   }
 
   public async getAssignees(uri: vscode.Uri): Promise<User[]> {


### PR DESCRIPTION
This keeps the default as `:`, but allows it to be overridden for other platforms like Gitlab (which uses `-` to denote the line block). 

[Example](https://gitlab.com/gitlab-org/gitlab/-/blob/master/.gitlab-ci.yml#L1-L13)

Not sure if there's a better way to structure this as its nested under Github settings, but it's really a setting for non-github platforms. Open to feedback!

Thanks!