### PR TITLE
Fix path format for Windows OS

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -339,7 +339,8 @@ export class WorkflowManager {
     const hostname = await this.git.getGitHostname(uri);
     const [owner, repo] = await this.git.getGitProviderOwnerAndRepository(uri);
     const branch = await this.git.getCurrentBranch(uri);
-    const currentFile = file.replace(/^\//, '');
+    const linuxStylePaths = file.replaceAll('\\', '/');
+    const currentFile = linuxStylePaths.replace(/^\//, '');
     return `https://${hostname}/${owner}/${repo}/blob/${branch}/${currentFile}#L${
       line + 1
     }:L${endLine + 1}`;


### PR DESCRIPTION
The `Browse current file` command is broken on windows machines.

For example, when I run the command for the file in question, it takes me to:

```none
https://github.com/KnisterPeter/vscode-github/blob/master/%5Csrc%5Cworkflow-manager.ts#L1:L1
```

Which, when decoded, is built like this:

```none
https://github.com/KnisterPeter/vscode-github/blob/master/\src\workflow-manager.ts#L1:L1
```

Because the file path in windows is like this:

```none
\src\workflow-manager.ts#L1:L1
```

Which means it misses the check to removing the opening slash, but also, github does not accept backslashes when routing to files.

It should be safe to convert any and all backslashes to forward slashes on any OS to represent directories.

----

_Alternatively_, when grabbing the file path in the first place here:

https://github.com/KnisterPeter/vscode-github/blob/d63944b7c6f9b4c5e7a7cfe245597030a5c350ab/src/commands/browse.ts#L70

It's would be possible to use OS agnostic paths like this:

```diff
- editor.document.fileName
+ editor.document.uri.path
```

[`fileName`](https://code.visualstudio.com/api/references/vscode-api#TextDocument.fileName) is an alias for [`uri.fsPath`](https://code.visualstudio.com/api/references/vscode-api#Uri.fsPath).  Where difference to the [`uri.path`](https://code.visualstudio.com/api/references/vscode-api#Uri.path) property is in the use of platform specific path separators as show here:

> ```ts
> const u = URI.parse('file://server/c$/folder/file.txt');
> u.authority === 'server';
> u.path === '/shares/c$/file.txt';
> u.fsPath === '\\serverc$\folder\file.txt';
> ```

However, I think that approach will muddy up the logic to replace the root, so easier to just convert all `\` chars to `/` chars.
